### PR TITLE
Disable translate button when input is empty or whitespace

### DIFF
--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -94,6 +94,8 @@ function handleSwap() {
   updateCharCount(leftText, leftCount);
   updateCopyButton(leftText, leftCopy);
   updateCopyButton(rightText, rightCopy);
+
+  translateBtn.disabled = !leftText.value.trim();
 }
 
 // Copy to clipboard


### PR DESCRIPTION
Fixes #9 