### PR TITLE
Pseudo live translation

### DIFF
--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -4,6 +4,7 @@ import { translateWithApi } from './apiClient.js';
 // State
 let isEmojiToWords = false;
 const MAX_CHARACTERS = 40;
+const AUTOTRANSLATE_TIMER = 4000;
 
 // DOM Elements
 const leftText = document.getElementById('leftText');
@@ -206,7 +207,7 @@ leftText.addEventListener('input', (e) => {
   translateTimeoutId = setTimeout(() => {
       console.log("Testing... this is the timeout");
       void handleTranslate(leftText.value);
-    }, 4000);
+    }, AUTOTRANSLATE_TIMER);
   
   
   // Enforce character limit using emoji-aware counting


### PR DESCRIPTION
Automatically submits an translation request when the user has not updated their request after a set amount of time(currently 4 seconds).

If the request is the same as the last one, no request is submitted. If the request is all white space, the request is not submitted.
Also makes it so that we do not clear the right text automatically when we start typing in the left box. It will be cleared when translation loading.