### PR TITLE
Disable Swap Button While Loading Translation

### DIFF
--- a/src/frontend/main.js
+++ b/src/frontend/main.js
@@ -22,6 +22,7 @@ let loadingTimer = null;
 
 function startLoading() {
   translateBtn.disabled = true;
+  swapBtn.disabled = true;
   rightText.classList.add('loading');
   rightText.value = 'Translating';
   let i = 0;
@@ -33,6 +34,7 @@ function startLoading() {
 
 function stopLoading() {
   translateBtn.disabled = false;
+  swapBtn.disabled = false;
   rightText.classList.remove('loading');
   if (loadingTimer) {
     clearInterval(loadingTimer);

--- a/src/frontend/styles.css
+++ b/src/frontend/styles.css
@@ -275,6 +275,12 @@ svg {
   transform: scale(0.95);
 }
 
+.swap-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: scale(0.95);
+}
+
 /* Footer */
 .footer {
   margin-top: 2rem;


### PR DESCRIPTION
If we swapped while the translation was occurring, "translating..." transferred to the left box. We don't want to swap while translating anyway so we disabled the ability to.